### PR TITLE
adding end trailers

### DIFF
--- a/proxy/http.go
+++ b/proxy/http.go
@@ -14,7 +14,7 @@ import (
 	"github.com/luraproject/lura/v2/transport/http/client"
 )
 
-var httpProxy = CustomHTTPProxyFactory(client.NewHTTPClient)
+var httpProxy = CustomHTTPProxyFactory(client.NewHTTP2Client)
 
 // HTTPProxyFactory returns a BackendFactory. The Proxies it creates will use the received net/http.Client
 func HTTPProxyFactory(client *http.Client) BackendFactory {

--- a/proxy/http_response.go
+++ b/proxy/http_response.go
@@ -58,7 +58,9 @@ func DefaultHTTPResponseParserFactory(cfg HTTPResponseParserConfig) HTTPResponse
 // http response body into the proxy response IO
 func NoOpHTTPResponseParser(ctx context.Context, resp *http.Response) (*Response, error) {
 	return &Response{
-		Data:       map[string]interface{}{},
+		Data:       map[string]interface{}{
+			"httpResp" : resp,
+		},
 		IsComplete: true,
 		Io:         NewReadCloserWrapper(ctx, resp.Body),
 		Metadata: Metadata{

--- a/router/gin/engine.go
+++ b/router/gin/engine.go
@@ -41,6 +41,7 @@ func NewEngine(cfg config.ServiceConfig, opt EngineOptions) *gin.Engine {
 	engine.RedirectFixedPath = true
 	engine.HandleMethodNotAllowed = true
 	engine.ContextWithFallback = true
+	engine.UseH2C = true
 
 	paths := []string{}
 

--- a/router/gin/render.go
+++ b/router/gin/render.go
@@ -162,6 +162,14 @@ func noopRender(c *gin.Context, response *proxy.Response) {
 		return
 	}
 	io.Copy(c.Writer, response.Io)
+	httpResp := response.Data["httpResp"].(*http.Response)
+	httpResp.Body.Close()
+	for k, vv := range httpResp.Trailer {
+		k = http.TrailerPrefix + k
+		for _, v := range vv {
+			c.Writer.Header().Add(k, v)
+		}
+	}
 }
 
 var emptyResponse = gin.H{}

--- a/router/gin/router.go
+++ b/router/gin/router.go
@@ -107,7 +107,7 @@ func (r ginRouter) Run(cfg config.ServiceConfig) {
 	go r.cfg.Engine.Run("XXXX")
 
 	r.cfg.Logger.Info("[SERVICE: Gin] Listening on port:", cfg.Port)
-	if err := r.runServerF(r.ctx, cfg, r.cfg.Engine); err != nil && err != http.ErrServerClosed {
+	if err := r.runServerF(r.ctx, cfg, r.cfg.Engine.Handler()); err != nil && err != http.ErrServerClosed {
 		r.cfg.Logger.Error(logPrefix, err.Error())
 	}
 

--- a/transport/http/client/executor.go
+++ b/transport/http/client/executor.go
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
-	Package client provides some http helpers to create http clients and executors
+Package client provides some http helpers to create http clients and executors
 */
 package client
 
 import (
 	"context"
+	"crypto/tls"
+	"net"
 	"net/http"
+
+	"golang.org/x/net/http2"
 )
 
 // HTTPRequestExecutor defines the interface of the request executor for the HTTP transport protocol
@@ -25,5 +29,30 @@ type HTTPClientFactory func(ctx context.Context) *http.Client
 
 // NewHTTPClient just returns the http default client
 func NewHTTPClient(_ context.Context) *http.Client { return defaultHTTPClient }
+
+func NewHTTP2Client(_ context.Context) *http.Client{
+	transport := &http.Transport{}
+	transportH2C := &h2cTransportWrapper{
+		Transport: &http2.Transport{
+			DialTLS: func(network, addr string, cfg *tls.Config) (net.Conn, error) {
+				return net.Dial(network, addr)
+			},
+			AllowHTTP: true,
+		},
+	}
+	transport.RegisterProtocol("h2c", transportH2C)
+	return &http.Client{
+		Transport: transport,
+	}
+}
+
+type h2cTransportWrapper struct {
+	*http2.Transport
+}
+
+func (t *h2cTransportWrapper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "http"
+	return t.Transport.RoundTrip(req)
+}
 
 var defaultHTTPClient = &http.Client{}


### PR DESCRIPTION
- Enabling HTTP2 in Gin Server
- Using HTTP2 client to connect to upstream servers
- Adding End trailers which are passed by GRPC Clients